### PR TITLE
chore: remove unused TextIO import, tighten comment, and add coverage tests

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import sys
 import os
 import argparse
-from typing import Optional, Tuple, List, TextIO
+from typing import Optional, Tuple, List
 
 class MindMapConverter:
     def __init__(self):
@@ -84,12 +84,8 @@ class MindMapConverter:
         return None
 
     def create_xml_node(self, parent: ET.Element, text: str) -> ET.Element:
-        # Check for hyperlinks in text [[url label]] or [[url]]
-        # Regex for [[url label]] or [[url]]
-        # We process matches. 
-        # Note: If multiple links exist, Freeplane only supports one URI per node typically via hook, 
-        # or we could leave others in text. We'll support extracting the first one to URI attribute.
-        
+        # Extract the first [[url label]] or [[url]] hyperlink; only one URI per node is supported.
+
         link_match = re.search(r"\[\[(.*?)(?: (.*?))?\]\]", text)
         uri = None
         if link_match:


### PR DESCRIPTION
## Summary

- **Closes #6**: `TextIO` was imported from `typing` but never referenced anywhere in the codebase; removed from the import line.
- **Closes #7**: replaced five verbose/redundant comment lines in `create_xml_node` with a single concise line that captures the full intent.
- **Closes #8**: adds three new tests to fill the coverage gap — roundtrip structure equality (`.mm` → `.puml` → `.mm`), empty Freemind map → bare PlantUML markers, and empty PlantUML markers → zero-child `<map>` element.

## Test plan

- [ ] `test_roundtrip_mm_to_puml_to_mm` — 3-level tree survives full roundtrip with identical structure
- [ ] `test_empty_map_to_plantuml` — `<map version="freeplane 1.9.13" />` → `@startmindmap\n@endmindmap`
- [ ] `test_empty_plantuml_to_map` — `@startmindmap\n@endmindmap` → `<map>` with zero child nodes
- [ ] All 13 tests pass: `python3 test_mindmapconverter.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)