### PR TITLE
chore: remove unused TextIO import, tighten comment, and add coverage tests

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import sys
 import os
 import argparse
-from typing import Optional, Tuple, List, TextIO
+from typing import Optional, Tuple, List
 
 class MindMapConverter:
     """Bidirectional converter between Freemind/Freeplane (.mm) and PlantUML mindmap (.puml) formats."""
@@ -85,12 +85,8 @@ class MindMapConverter:
 
     def create_xml_node(self, parent: ET.Element, text: str) -> ET.Element:
         """Create a Freemind XML node under parent, extracting any [[url label]] hyperlink."""
-        # Check for hyperlinks in text [[url label]] or [[url]]
-        # Regex for [[url label]] or [[url]]
-        # We process matches. 
-        # Note: If multiple links exist, Freeplane only supports one URI per node typically via hook, 
-        # or we could leave others in text. We'll support extracting the first one to URI attribute.
-        
+        # Extract the first [[url label]] or [[url]] hyperlink; only one URI per node is supported.
+
         link_match = re.search(r"\[\[(.*?)(?: (.*?))?\]\]", text)
         uri = None
         if link_match:

--- a/test_mindmapconverter.py
+++ b/test_mindmapconverter.py
@@ -181,5 +181,40 @@ Child line 2;
         puml_output = self.converter.freemind_to_plantuml(xml_content)
         self.assertIn("A & B <tag>", puml_output)
 
+    def _extract_tree(self, element: ET.Element):
+        """Recursively extract (TEXT, [children]) from an XML node element."""
+        return (element.get("TEXT"), [self._extract_tree(c) for c in element.findall("node")])
+
+    def test_roundtrip_mm_to_puml_to_mm(self):
+        """A 3-level Freemind map survives a .mm → .puml → .mm roundtrip with identical structure."""
+        original_xml = """<map version="freeplane 1.9.13">
+<node TEXT="Root">
+<node TEXT="Child 1"/>
+<node TEXT="Child 2">
+<node TEXT="Grandchild"/>
+</node>
+</node>
+</map>"""
+        puml = self.converter.freemind_to_plantuml(original_xml)
+        roundtripped_xml = self.converter.plantuml_to_freemind(puml)
+
+        original_root = ET.fromstring(original_xml).find("node")
+        roundtripped_root = ET.fromstring(roundtripped_xml).find("node")
+        self.assertEqual(self._extract_tree(original_root), self._extract_tree(roundtripped_root))
+
+    def test_empty_map_to_plantuml(self):
+        """An empty Freemind map produces exactly @startmindmap\\n@endmindmap."""
+        xml_content = '<map version="freeplane 1.9.13" />'
+        result = self.converter.freemind_to_plantuml(xml_content)
+        self.assertEqual(result.strip(), "@startmindmap\n@endmindmap")
+
+    def test_empty_plantuml_to_map(self):
+        """An empty PlantUML mindmap produces a <map> with zero child nodes."""
+        puml_content = "@startmindmap\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml_content)
+        root = ET.fromstring(xml_output)
+        self.assertEqual(root.tag, "map")
+        self.assertEqual(len(root.findall("node")), 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- **Closes #6**: `TextIO` was imported from `typing` but never referenced anywhere in the codebase; removed from the import line.
- **Closes #7**: replaced five verbose/redundant comment lines in `create_xml_node` with a single concise line.
- **Closes #8**: adds three new tests — roundtrip structure equality (`.mm` → `.puml` → `.mm`), empty Freemind map → bare PlantUML markers, and empty PlantUML markers → zero-child `<map>` element.

## Test plan

- [ ] `test_roundtrip_mm_to_puml_to_mm` — 3-level tree survives full roundtrip with identical structure
- [ ] `test_empty_map_to_plantuml` — `<map version="freeplane 1.9.13" />` → `@startmindmap\n@endmindmap`
- [ ] `test_empty_plantuml_to_map` — `@startmindmap\n@endmindmap` → `<map>` with zero child nodes
- [ ] All 17 tests pass: `python3 test_mindmapconverter.py`