### PR TITLE
fix: strip leading whitespace from multiline continuation lines

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -159,7 +159,7 @@ class MindMapConverter:
                                 i += 1
                                 break
                             else:
-                                multiline_text.append(lines[i].rstrip())
+                                multiline_text.append(lines[i].strip())
                                 i += 1
                         else:
                             raise ValueError(

--- a/test_mindmapconverter.py
+++ b/test_mindmapconverter.py
@@ -249,6 +249,19 @@ Line 2
             self.converter.plantuml_to_freemind(puml_content)
         self.assertIn("Unterminated", str(ctx.exception))
 
+    def test_multiline_continuation_leading_whitespace_stripped(self):
+        """Leading whitespace on multiline continuation lines must be stripped."""
+        puml_content = """@startmindmap
+* Root
+** :Line 1
+    indented continuation;
+@endmindmap"""
+        xml_output = self.converter.plantuml_to_freemind(puml_content)
+        root = ET.fromstring(xml_output)
+        child = root.find("node").find("node")
+        self.assertIn("Line 1", child.get("TEXT"))
+        self.assertIn("indented continuation", child.get("TEXT"))
+        self.assertNotIn("    indented", child.get("TEXT"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- **Closes #14**: continuation lines inside a multiline node block were collected with `rstrip()`, which preserved leading whitespace. Changed to `strip()` so they are trimmed consistently with the opening line (which goes through `parse_plantuml_line` → `.strip()`).
- Adds `test_multiline_continuation_leading_whitespace_stripped` to pin the corrected behaviour.

## Test plan

- [ ] `test_multiline_continuation_leading_whitespace_stripped` — indented continuation line must not embed leading spaces in node TEXT
- [ ] All existing multiline tests still pass
- [ ] All 21 tests pass: `python3 test_mindmapconverter.py`