### PR TITLE
fix: add NAME="ExternalObject" to hook element for Freeplane compatibility

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -108,6 +108,7 @@ class MindMapConverter:
 
         if uri:
             hook = ET.SubElement(node, "hook")
+            hook.set("NAME", "ExternalObject")
             hook.set("URI", uri)
 
         return node

--- a/test_mindmapconverter.py
+++ b/test_mindmapconverter.py
@@ -119,6 +119,7 @@ Child line 2;
         self.assertEqual(node.get("TEXT"), "Link")
         hook = node.find("hook")
         self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("NAME"), "ExternalObject")
         self.assertEqual(hook.get("URI"), "http://example.com")
 
     def test_hyperlinks_freemind_to_plantuml(self):


### PR DESCRIPTION
## Summary

- **Closes #13**: adds `NAME="ExternalObject"` to the `<hook>` element written by `create_xml_node`. Without this attribute Freeplane does not recognise the URI and the hyperlink is invisible when the `.mm` file is opened directly in Freeplane.
- The reader (`parse_xml_node`) already finds hooks solely by checking for a `URI` attribute, so round-trips continue to work unchanged.
- Updated `test_hyperlinks_plantuml_to_freemind` to assert `NAME="ExternalObject"` is present.

## Test plan

- [ ] `test_hyperlinks_plantuml_to_freemind` — hook has both `NAME="ExternalObject"` and correct `URI`
- [ ] All 20 tests pass: `python3 test_mindmapconverter.py`