### PR TITLE
test: add 37 additional edge case tests for CLI, links, multi-root conversions

### DIFF
--- a/test_additional_edge_cases.py
+++ b/test_additional_edge_cases.py
@@ -1,0 +1,502 @@
+"""Additional edge case tests for mindmapconverter parser.
+
+This file contains tests for:
+- main() CLI function with argparse (file I/O paths)
+- Multiple top-level nodes in Freemind maps
+- Malformed link patterns in create_xml_node
+- Edge cases in freemind_to_markdown and markdown_to_freemind
+- Boundary conditions in the conversion logic
+"""
+
+import unittest
+import xml.etree.ElementTree as ET
+import os
+import sys
+import tempfile
+from io import StringIO
+from unittest.mock import patch
+
+from mindmapconverter import MindMapConverter, main
+
+
+class TestMainCLI(unittest.TestCase):
+    """Tests for the main() CLI entry point with file I/O."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+        self.temp_dir = tempfile.mkdtemp()
+
+    def _write_input(self, content: str, filename: str) -> str:
+        path = os.path.join(self.temp_dir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return path
+
+    def test_mm_file_to_plantuml_stdout(self):
+        """CLI: .mm input outputs PlantUML to stdout."""
+        xml_content = '<map version="freeplane 1.9.13"><node TEXT="Root"/></map>'
+        input_path = self._write_input(xml_content, "test.mm")
+
+        with patch("sys.argv", ["mindmapconverter", input_path]), \
+             patch("sys.stdout", new_callable=StringIO) as stdout:
+            main()
+            output = stdout.getvalue()
+            self.assertIn("@startmindmap", output)
+            self.assertIn("Root", output)
+            self.assertIn("@endmindmap", output)
+
+    def test_puml_file_to_freemind_stdout(self):
+        """CLI: .puml input outputs Freemind XML to stdout."""
+        puml = "@startmindmap\n* Root\n@endmindmap\n"
+        input_path = self._write_input(puml, "test.puml")
+
+        with patch("sys.argv", ["mindmapconverter", input_path]), \
+             patch("sys.stdout", new_callable=StringIO) as stdout:
+            main()
+            output = stdout.getvalue()
+            root = ET.fromstring(output)
+            self.assertEqual(root.tag, "map")
+            self.assertEqual(root.find("node").get("TEXT"), "Root")
+
+    def test_mm_file_to_md_with_flag(self):
+        """CLI: .mm with --to-md outputs Markdown to stdout."""
+        xml_content = '<map version="freeplane 1.9.13"><node TEXT="Root"><node TEXT="Child"/></node></map>'
+        input_path = self._write_input(xml_content, "test.mm")
+
+        with patch("sys.argv", ["mindmapconverter", input_path, "--to-md"]), \
+             patch("sys.stdout", new_callable=StringIO) as stdout:
+            main()
+            output = stdout.getvalue()
+            self.assertEqual(output.strip(), "# Root\n- Child")
+
+    def test_md_file_to_freemind(self):
+        """CLI: .md input outputs Freemind XML to stdout."""
+        md_content = "# Root\n- Child\n"
+        input_path = self._write_input(md_content, "test.md")
+
+        with patch("sys.argv", ["mindmapconverter", input_path]), \
+             patch("sys.stdout", new_callable=StringIO) as stdout:
+            main()
+            output = stdout.getvalue()
+            root = ET.fromstring(output)
+            self.assertEqual(root.find("node").get("TEXT"), "Root")
+
+    def test_md_file_to_freemind_with_flag(self):
+        """CLI: any extension with --from-md forces Markdown parsing."""
+        md_content = "# Root\n- Child\n"
+        input_path = self._write_input(md_content, "test.txt")
+
+        with patch("sys.argv", ["mindmapconverter", input_path, "--from-md"]), \
+             patch("sys.stdout", new_callable=StringIO) as stdout:
+            main()
+            output = stdout.getvalue()
+            root = ET.fromstring(output)
+            self.assertEqual(root.find("node").get("TEXT"), "Root")
+
+    def test_file_not_found_exits_1(self):
+        """CLI: nonexistent file prints error and exits with code 1."""
+        with patch("sys.argv", ["mindmapconverter", "/nonexistent/file.mm"]), \
+             patch("sys.stderr", new_callable=StringIO) as stderr:
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertEqual(cm.exception.code, 1)
+            self.assertIn("not found", stderr.getvalue())
+
+    def test_mm_to_file_output(self):
+        """CLI: -o flag writes output to file."""
+        xml_content = '<map version="freeplane 1.9.13"><node TEXT="Test"/></map>'
+        input_path = self._write_input(xml_content, "test.mm")
+        output_path = os.path.join(self.temp_dir, "output.puml")
+
+        with patch("sys.argv", ["mindmapconverter", input_path, "-o", output_path]), \
+             patch("sys.stdout", new_callable=StringIO) as stdout:
+            main()
+            # Nothing should go to stdout
+            self.assertEqual(stdout.getvalue(), "")
+
+        with open(output_path) as f:
+            output = f.read()
+        self.assertIn("@startmindmap", output)
+        self.assertIn("Test", output)
+
+    def test_md_to_file_output(self):
+        """CLI: .md to .mm with -o writes XML output."""
+        md_content = "# Root\n- A\n- B\n"
+        input_path = self._write_input(md_content, "test.md")
+        output_path = os.path.join(self.temp_dir, "output.mm")
+
+        with patch("sys.argv", ["mindmapconverter", input_path, "-o", output_path]):
+            main()
+
+        with open(output_path) as f:
+            output = f.read()
+        root = ET.fromstring(output)
+        self.assertEqual(root.find("node").get("TEXT"), "Root")
+        children = root.find("node").findall("node")
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "A")
+        self.assertEqual(children[1].get("TEXT"), "B")
+
+    def test_invalid_md_raises_value_error(self):
+        """CLI: invalid .md content (no H1) exits with code 1."""
+        md_content = "Just text, no header"
+        input_path = self._write_input(md_content, "test.md")
+
+        with patch("sys.argv", ["mindmapconverter", input_path]), \
+             patch("sys.stderr", new_callable=StringIO) as stderr:
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertEqual(cm.exception.code, 1)
+            self.assertIn("No H1 header", stderr.getvalue())
+
+
+class TestMultipleRootNodes(unittest.TestCase):
+    """Tests for Freemind maps with multiple top-level nodes."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_freemind_with_multiple_top_level_nodes_to_plantuml(self):
+        """Freemind with multiple root <node> elements converts to separate PlantUML roots."""
+        xml_content = '''<map version="freeplane 1.9.13">
+<node TEXT="Root1"><node TEXT="Child A"/></node>
+<node TEXT="Root2"><node TEXT="Child B"/></node>
+</map>'''
+        puml = self.converter.freemind_to_plantuml(xml_content)
+        # Should have both root nodes at level 1
+        self.assertIn("* Root1", puml)
+        self.assertIn("* Root2", puml)
+        self.assertIn("** Child A", puml)
+        self.assertIn("** Child B", puml)
+
+    def test_freemind_with_multiple_top_level_nodes_to_markdown(self):
+        """Freemind with multiple root nodes converts first root to H1."""
+        xml_content = '''<map version="freeplane 1.9.13">
+<node TEXT="First Root"><node TEXT="A"/></node>
+<node TEXT="Second Root"><node TEXT="B"/></node>
+</map>'''
+        md = self.converter.freemind_to_markdown(xml_content)
+        self.assertIn("# First Root", md)
+        self.assertIn("- A", md)
+
+    def test_single_node_as_root_element(self):
+        """A single <node> element as root (without <map> wrapper) converts correctly."""
+        xml_content = '<node TEXT="Root"><node TEXT="Child"/></node>'
+        puml = self.converter.freemind_to_plantuml(xml_content)
+        self.assertIn("* Root", puml)
+        self.assertIn("** Child", puml)
+
+        md = self.converter.freemind_to_markdown(xml_content)
+        self.assertIn("# Root", md)
+        self.assertIn("- Child", md)
+
+
+class TestCreateXmlNodeEdgeCases(unittest.TestCase):
+    """Edge cases for the create_xml_node link extraction."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_multiple_link_patterns_only_first_extracted(self):
+        """When text contains multiple [[url label]] patterns, only the first is extracted."""
+        parent = ET.Element("map")
+        text_with_two = "[[http://first.com First]] some text [[http://second.com Second]]"
+        node = self.converter.create_xml_node(parent, text_with_two)
+        # Second pattern should remain in TEXT (not extracted)
+        self.assertIn("First", node.get("TEXT"))
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://first.com")
+
+    def test_malformed_link_double_bracket_no_close(self):
+        """Malformed [[ without closing ]] is left in TEXT as-is."""
+        parent = ET.Element("map")
+        node = self.converter.create_xml_node(parent, "text [[no close")
+        self.assertEqual(node.get("TEXT"), "text [[no close")
+        self.assertIsNone(node.find("hook"))
+
+    def test_link_with_special_characters_in_url(self):
+        """URL with query params and special chars is extracted correctly."""
+        parent = ET.Element("map")
+        node = self.converter.create_xml_node(parent, "[[https://example.com/path?q=1&b=2 Link]]")
+        self.assertEqual(node.get("TEXT"), "Link")
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "https://example.com/path?q=1&b=2")
+        self.assertIsNone(node.get("URI"))  # URI is on hook, not node
+
+    def test_link_with_empty_label(self):
+        """[[url ]] with trailing space and a space as label."""
+        parent = ET.Element("map")
+        node = self.converter.create_xml_node(parent, "[[http://example.com ]]")
+        # Regex: \[\[(.*?)(?: (.*?))?\]\] against "[[http://example.com ]]"
+        # group(1)="http://example.com", group(2)="" (the space after label is captured by optional space,
+        # then .*? matches empty, and ]] follows)
+        # Actually: let me check - regex finds [[ then (.*?) greedily takes "http", then space and empty label
+        # Since group(2)="" is falsy, the else branch is taken: URI="http://example.com", TEXT="http://example.com"
+        self.assertEqual(node.get("TEXT"), "http://example.com")
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://example.com")
+
+    def test_link_with_empty_url(self):
+        """[[]] with empty content."""
+        parent = ET.Element("map")
+        # [[]] - regex won't match because (.*?) needs something between [[ and ]]
+        # Actually it would match with empty string
+        text = "some [[]] text"
+        node = self.converter.create_xml_node(parent, text)
+        self.assertEqual(node.get("TEXT"), "some  text")
+
+
+class TestFreemindToMarkdownEdgeCases(unittest.TestCase):
+    """Edge cases specific to freemind_to_markdown conversion."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_empty_nodes_list_returns_empty_string(self):
+        """Freemind XML with no <node> at root level returns empty string."""
+        xml = '<empty version="freeplane 1.9.13"/>'
+        result = self.converter.freemind_to_markdown(xml)
+        self.assertEqual(result, "")
+
+    def test_multiline_text_renders_as_br_in_markdown(self):
+        """Multiline text in Freemind renders with <br> in Markdown output."""
+        xml = '''<map version="freeplane 1.9.13">
+<node TEXT="Line1&#10;Line2&#10;Line3"/>
+</map>'''
+        result = self.converter.freemind_to_markdown(xml)
+        self.assertIn("Line1<br>Line2<br>Line3", result)
+
+    def test_nested_multiline_text_with_links(self):
+        """Combined: nested nodes with multiline text and hyperlinks."""
+        xml = '''<map version="freeplane 1.9.13">
+<node TEXT="Root">
+<node TEXT="Line1&#10;Line2">
+<node TEXT="Nested Link">
+<hook URI="http://example.com"/>
+</node>
+</node>
+</node>
+</map>'''
+        result = self.converter.freemind_to_markdown(xml)
+        self.assertIn("Line1<br>Line2", result)
+        self.assertIn("[Nested Link](http://example.com)", result)
+
+    def test_unicode_in_freemind_to_markdown_deep_hierarchy(self):
+        """Unicode text at various depths renders correctly."""
+        xml = '''<map version="freeplane 1.9.13">
+<node TEXT="日本語 Root">
+<node TEXT="Émoji 🎯">
+<node TEXT="中文测试"/>
+</node>
+</node>
+</map>'''
+        result = self.converter.freemind_to_markdown(xml)
+        self.assertIn("日本語 Root", result)
+        self.assertIn("Émoji 🎯", result)
+        self.assertIn("中文测试", result)
+
+
+class TestMarkdownToFreemindEdgeCases(unittest.TestCase):
+    """Edge cases specific to markdown_to_freemind conversion."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_non_header_non_list_lines_ignored(self):
+        """Lines that are neither H1 nor list items are silently ignored."""
+        md = "# Root\nSome regular text\n- Child\nMore text\n- Child2"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        children = root.find("node").findall("node")
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "Child")
+        self.assertEqual(children[1].get("TEXT"), "Child2")
+
+    def test_h1_after_list_items_ignored(self):
+        """H1 headers after the first one are ignored (treated as regular lines)."""
+        md = "# Root\n- Child\n## Not a root\n- Another child"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        children = root_node.findall("node")
+        # The ## Not a root is ignored, so Another Child is still a sibling of Child
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "Child")
+        self.assertEqual(children[1].get("TEXT"), "Another child")
+
+    def test_empty_list_item_text(self):
+        """List item with only whitespace after marker is handled."""
+        md = "# Root\n   "
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        # The whitespace-only line should not match the list pattern
+        self.assertEqual(root.find("node").get("TEXT"), "Root")
+        self.assertEqual(len(root.find("node").findall("node")), 0)
+
+    def test_link_text_with_bracket_chars_not_extracted(self):
+        """Markdown link text containing ] chars: regex cannot match, text is preserved as-is."""
+        md = "# Root\n- [A.B*C+?|()[] Test](http://example.com)"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        node = root.find("node").find("node")
+        # The regex r'\[([^\]]+)\]\(([^)]+)\)' fails when the link text contains ']'
+        # So the entire bracket expression is kept as raw TEXT
+        self.assertEqual(node.get("TEXT"), "[A.B*C+?|()[] Test](http://example.com)")
+        self.assertIsNone(node.find("hook"))
+
+    def test_multiline_text_with_br_in_markdown_input(self):
+        """Multiple <br> tags in Markdown convert to actual newlines."""
+        md = "# Root\n- Line1<br>Line2<br>Line3"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        node = root.find("node").find("node")
+        self.assertEqual(node.get("TEXT"), "Line1\nLine2\nLine3")
+
+
+class TestPlantumlToFreemindEdgeCases(unittest.TestCase):
+    """Edge cases for plantuml_to_freemind conversion."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_multiple_root_nodes_in_plantuml(self):
+        """PlantUML with multiple level-1 nodes at the same level."""
+        puml = "@startmindmap\n* Root1\n* Root2\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        nodes = root.findall("node")
+        self.assertEqual(len(nodes), 2)
+        self.assertEqual(nodes[0].get("TEXT"), "Root1")
+        self.assertEqual(nodes[1].get("TEXT"), "Root2")
+
+    def test_deep_nesting_with_level_decrease_then_increase(self):
+        """PlantUML: deep nest, go shallow, then deep again."""
+        puml = """@startmindmap
+* Root
+** Level2
+*** Level3
+** BackTo2
+*** DeepAgain
+@endmindmap"""
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        children = root_node.findall("node")
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "Level2")
+        self.assertEqual(children[1].get("TEXT"), "BackTo2")
+
+    def test_multiline_with_empty_continuation_lines(self):
+        """Multiline node with empty continuation line."""
+        puml = """@startmindmap
+* Root
+** :Line 1
+
+Line 3;
+@endmindmap"""
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        child = root.find("node").find("node")
+        text = child.get("TEXT")
+        self.assertIn("Line 1", text)
+        self.assertIn("Line 3", text)
+
+    def test_multiline_single_line_form_empty_text(self):
+        """Multiline node that is just `:;` produces empty text."""
+        puml = "@startmindmap\n* :\n@endmindmap"
+        # This creates an empty multiline start which then waits for continuation
+        # Actually with just `* :` it sets is_multiline_start=True and text=""
+        # Then waits for continuation - if no continuation found before @endmindmap, raises ValueError
+        with self.assertRaises(ValueError):
+            self.converter.plantuml_to_freemind(puml)
+
+    def test_plantuml_with_tab_characters_before_asterisk(self):
+        """Tabs before asterisk at line start are handled."""
+        puml = "@startmindmap\n\t* Root\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        self.assertEqual(root.find("node").get("TEXT"), "Root")
+
+    def test_link_with_text_containing_double_brackets(self):
+        """Link text that itself contains [[ triggers only the outer pattern."""
+        puml = "@startmindmap\n* [[http://example.com Text with [[inner]] brackets]]\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        node = root.find("node")
+        # The regex \[\[(.*?)(?: (.*?))?\]\] is non-greedy: it captures "http://example.com" as URI
+        # and "Text with [[inner" as label. The remaining "]] brackets]]" stays in TEXT.
+        # Actually the replace replaces the first match of [[http://example.com Text with [[inner]] brackets]]
+        # which replaces everything including the inner ]], leaving " brackets]]" -> wait
+        # Let's just verify the observed behavior
+        self.assertIn("[[inner brackets", node.get("TEXT"))
+        self.assertIn("Text with", node.get("TEXT"))
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://example.com")
+
+class TestFreemindToPlantumlEdgeCases(unittest.TestCase):
+    """Edge cases for freemind_to_plantuml conversion."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_single_node_freemind(self):
+        """Freemind with just one node (no children) produces minimal output."""
+        xml = '<map version="freeplane 1.9.13"><node TEXT="Only Node"/></map>'
+        result = self.converter.freemind_to_plantuml(xml)
+        expected = "@startmindmap\n* Only Node\n@endmindmap"
+        self.assertEqual(result.strip(), expected)
+
+    def test_node_with_multiple_hooks_picks_first_uri(self):
+        """Node with multiple hook elements uses the first URI."""
+        xml = '''<map version="freeplane 1.9.13">
+<node TEXT="Root">
+<hook URI="http://first.com"/>
+<hook URI="http://second.com"/>
+</node>
+</map>'''
+        puml = self.converter.freemind_to_plantuml(xml)
+        self.assertIn("http://first.com", puml)
+        # The second URI should NOT appear
+        self.assertNotIn("http://second.com", puml)
+
+    def test_empty_map_tag(self):
+        """Freemind with just <map> tag produces minimal PlantUML output."""
+        xml = "<map version=\"freeplane 1.9.13\"></map>"
+        result = self.converter.freemind_to_plantuml(xml)
+        self.assertEqual(result.strip(), "@startmindmap\n@endmindmap")
+
+
+class TestRoundtripEdgeCases(unittest.TestCase):
+    """Roundtrip tests with edge cases."""
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_plantuml_to_freemind_to_plantuml_with_multiple_roots(self):
+        """PlantUML with multiple roots survives roundtrip."""
+        original = "@startmindmap\n* A\n* B\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(original)
+        roundtripped = self.converter.freemind_to_plantuml(xml)
+        # Note: Freemind wraps multiple roots in a <map>, so PlantUML re-extraction 
+        # will produce * A and * B at level 1
+        self.assertIn("* A", roundtripped)
+        self.assertIn("* B", roundtripped)
+
+    def test_plantuml_roundtrip_with_multiline(self):
+        """PlantUML with multiline node survives roundtrip."""
+        original = "@startmindmap\n* Root\n** :Line 1\nLine 2;\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(original)
+        roundtripped = self.converter.freemind_to_plantuml(xml)
+        self.assertIn("* Root", roundtripped)
+        self.assertIn("Line 1", roundtripped)
+        self.assertIn("Line 2", roundtripped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_edge_cases.py
+++ b/test_edge_cases.py
@@ -1,0 +1,491 @@
+import unittest
+import xml.etree.ElementTree as ET
+from mindmapconverter import MindMapConverter
+
+
+class TestMindMapConverterEdgeCases(unittest.TestCase):
+    """Edge case tests for the mindmapconverter parser covering:
+    - Malformed PlantUML input (incomplete nodes, missing closers)
+    - Empty input / whitespace-only input
+    - Deeply nested hierarchies (100+ levels)
+    - Special characters (unicode, emojis, XML entities)
+    - Very long node labels
+    - Files with mixed line endings
+    - Additional parser edge cases for parse_plantuml_line and create_xml_node
+    """
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    # =========================================================================
+    # Empty / Whitespace-only input
+    # =========================================================================
+
+    def test_empty_string_plantuml_to_freemind(self):
+        """Empty string input must raise ValueError (missing @startmindmap)."""
+        with self.assertRaises(ValueError):
+            self.converter.plantuml_to_freemind("")
+
+    def test_whitespace_only_plantuml_to_freemind(self):
+        """Whitespace-only input must raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.converter.plantuml_to_freemind("   \n  \n\t ")
+
+    def test_whitespace_only_markdown_to_freemind(self):
+        """Whitespace-only Markdown must raise ValueError (no H1 header)."""
+        with self.assertRaises(ValueError):
+            self.converter.markdown_to_freemind("   \n  \n\t ")
+
+    def test_only_startmindmap_raises(self):
+        """Input with @startmindmap but no @endmindmap must raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.converter.plantuml_to_freemind("@startmindmap\n* Root")
+
+    def test_only_endmindmap_raises(self):
+        """Input with @endmindmap but no @startmindmap must raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.converter.plantuml_to_freemind("@endmindmap")
+
+    def test_empty_string_freemind_to_plantuml(self):
+        """Empty string Freemind XML must raise ValueError (ET.ParseError)."""
+        with self.assertRaises(ValueError):
+            self.converter.freemind_to_plantuml("")
+
+    def test_whitespace_only_freemind_to_plantuml(self):
+        """Whitespace-only Freemind XML must raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.converter.freemind_to_plantuml("   \n  \n")
+
+    def test_empty_string_freemind_to_markdown(self):
+        """Empty string Freemind XML must raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.converter.freemind_to_markdown("")
+
+    # =========================================================================
+    # Malformed PlantUML input (incomplete nodes, missing closers)
+    # =========================================================================
+
+    def test_malformed_xml_freemind_to_plantuml(self):
+        """Malformed XML (not well-formed) must raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.converter.freemind_to_plantuml("<not xml><unclosed>")
+
+    def test_plantuml_with_only_comments_has_no_nodes(self):
+        """PlantUML with only comments between markers produces zero nodes."""
+        xml_output = self.converter.plantuml_to_freemind(
+            "@startmindmap\n' comment line\n' another comment\n@endmindmap"
+        )
+        root = ET.fromstring(xml_output)
+        self.assertEqual(len(root.findall("node")), 0)
+
+    def test_plantuml_with_no_text_node_content(self):
+        """A node with only asterisks and no text produces an empty TEXT attribute."""
+        xml_output = self.converter.plantuml_to_freemind(
+            "@startmindmap\n*\n@endmindmap"
+        )
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertIsNotNone(root_node)
+        self.assertEqual(root_node.get("TEXT"), "")
+
+    def test_plantuml_unterminated_multiline_at_eof(self):
+        """Multiline started right before @endmindmap (missing ';') must raise ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.converter.plantuml_to_freemind(
+                "@startmindmap\n* Root\n** :start of multi\n@endmindmap"
+            )
+        self.assertIn("Unterminated", str(ctx.exception))
+
+    # =========================================================================
+    # Deeply nested hierarchies (100+ levels)
+    # =========================================================================
+
+    def test_100_level_plantuml_nesting(self):
+        """PlantUML with 100 levels of nesting converts correctly."""
+        puml_lines = ["@startmindmap"]
+        for i in range(1, 101):
+            puml_lines.append("*" * i + f" Level{i}")
+        puml_lines.append("@endmindmap")
+        puml_content = "\n".join(puml_lines)
+
+        xml_output = self.converter.plantuml_to_freemind(puml_content)
+        root = ET.fromstring(xml_output)
+
+        # Walk the tree to verify all 100 levels exist
+        node = root.find("node")
+        self.assertIsNotNone(node)
+        self.assertEqual(node.get("TEXT"), "Level1")
+        for level in range(2, 101):
+            children = node.findall("node")
+            self.assertEqual(len(children), 1, f"Level {level} should have exactly 1 child")
+            node = children[0]
+            self.assertEqual(node.get("TEXT"), f"Level{level}")
+
+    def test_100_level_freemind_to_markdown(self):
+        """Freemind with 100 levels of nesting converts to Markdown."""
+        # Build deep XML with 100 levels
+        xml_parts = ['<map version="freeplane 1.9.13">', '<node TEXT="Root">']
+        for i in range(1, 101):
+            xml_parts.append('<node TEXT="' + f"L{i}" + '">')
+        xml_parts[-1] = '<node TEXT="L100"/>'  # Replace last open with self-closing
+        for _ in range(100):
+            xml_parts.append("</node>")
+        xml_parts.append("</map>")
+        xml_content = "\n".join(xml_parts)
+
+        result = self.converter.freemind_to_markdown(xml_content)
+        lines = result.split("\n")
+        self.assertEqual(lines[0], "# Root")
+        # indent = "  " * (depth - 1); L1 is depth 1 (indent ""), L100 is depth 100
+        # L1 at index 1, L100 at index 100
+        expected_indent = "  " * 99  # depth 100 - 1 = 99
+        self.assertEqual(lines[100], f"{expected_indent}- L100")
+
+    def test_100_level_markdown_to_freemind(self):
+        """Markdown with 100 levels of nesting converts to Freemind."""
+        md_parts = ["# Root"]
+        for i in range(1, 101):
+            indent = "  " * (i - 1)
+            md_parts.append(f"{indent}- Level{i}")
+        md_content = "\n".join(md_parts)
+
+        xml_output = self.converter.markdown_to_freemind(md_content)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+
+        # Walk the tree
+        node = root_node
+        for i in range(1, 101):
+            children = node.findall("node")
+            self.assertEqual(len(children), 1, f"Level {i} should have exactly 1 child")
+            node = children[0]
+            self.assertEqual(node.get("TEXT"), f"Level{i}")
+
+    def test_deep_freemind_to_plantuml(self):
+        """Freemind with deep hierarchy converts to proper PlantUML indentation."""
+        # Build moderate depth XML (20 levels)
+        xml_parts = ['<map version="freeplane 1.9.13">', '<node TEXT="Root">']
+        for i in range(1, 21):
+            xml_parts.append(f'<node TEXT="D{i}">')
+        xml_parts[-1] = '<node TEXT="D20"/>'
+        for _ in range(20):
+            xml_parts.append("</node>")
+        xml_parts.append("</map>")
+        xml_content = "\n".join(xml_parts)
+
+        puml = self.converter.freemind_to_plantuml(xml_content)
+        # Root is *, D20 should be twenty asterisks
+        self.assertIn("* Root", puml)
+        expected = "*" * 20 + " D20"
+        self.assertIn(expected, puml)
+
+    # =========================================================================
+    # Special characters in node text (unicode, emojis, XML entities)
+    # =========================================================================
+
+    def test_unicode_characters_in_plantuml(self):
+        """Unicode characters in PlantUML node text are preserved."""
+        puml = '@startmindmap\n* 日本語テスト\n** émojis café\n@endmindmap'
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "日本語テスト")
+        child = root_node.find("node")
+        self.assertEqual(child.get("TEXT"), "émojis café")
+
+    def test_emoji_in_plantuml_node(self):
+        """Emojis in PlantUML node text are preserved."""
+        puml = "@startmindmap\n* 🌳 Root 🌳\n** 🍃 Child 1 🍃\n** 🌺 Child 2\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "🌳 Root 🌳")
+        children = root_node.findall("node")
+        self.assertEqual(children[0].get("TEXT"), "🍃 Child 1 🍃")
+        self.assertEqual(children[1].get("TEXT"), "🌺 Child 2")
+
+    def test_unicode_in_freemind_xml(self):
+        """Unicode in Freemind XML TEXT attributes survives conversion."""
+        xml_content = '<map version="freeplane 1.9.13"><node TEXT="Über naïve résumé 日本語"/></map>'
+        result = self.converter.freemind_to_plantuml(xml_content)
+        self.assertIn("Über naïve résumé 日本語", result)
+
+    def test_xml_entities_in_plantuml_node(self):
+        """Common XML entity-like text in PlantUML nodes is preserved."""
+        # PlantUML uses raw text, not XML. &, <, > should pass through.
+        puml = "@startmindmap\n* A & B < C > D\n** E=F\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertIn("&", root_node.get("TEXT"))
+        self.assertIn("<", root_node.get("TEXT"))
+        self.assertIn(">", root_node.get("TEXT"))
+        child = root_node.find("node")
+        self.assertEqual(child.get("TEXT"), "E=F")
+
+    def test_emoji_in_markdown_to_freemind(self):
+        """Emojis in Markdown input are preserved in Freemind XML."""
+        md = "# 🏠 Home\n- 🛏️ Bedroom\n- 🍳 Kitchen"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "🏠 Home")
+        children = root_node.findall("node")
+        self.assertEqual(children[0].get("TEXT"), "🛏️ Bedroom")
+        self.assertEqual(children[1].get("TEXT"), "🍳 Kitchen")
+
+    def test_emoji_in_freemind_to_markdown(self):
+        """Emojis in Freemind XML survive conversion to Markdown."""
+        xml = '<map version="freeplane 1.9.13"><node TEXT="🎯 Target"><node TEXT="✅ Done"/></node></map>'
+        md = self.converter.freemind_to_markdown(xml)
+        self.assertIn("🎯 Target", md)
+        self.assertIn("✅ Done", md)
+
+    def test_special_chars_roundtrip_plantuml_to_freemind(self):
+        """Special characters (+, -, #, @, $) in PlantUML survive roundtrip."""
+        puml = "@startmindmap\n* +plus -minus #hash @at $dollar\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        root_node = root.find("node")
+        self.assertIn("+plus", root_node.get("TEXT"))
+        self.assertIn("-minus", root_node.get("TEXT"))
+        self.assertIn("#hash", root_node.get("TEXT"))
+        self.assertIn("@at", root_node.get("TEXT"))
+        self.assertIn("$dollar", root_node.get("TEXT"))
+
+    def test_tab_characters_in_node_text(self):
+        """Tab characters in node text survive conversion."""
+        puml = "@startmindmap\n* text\twith\ttabs\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        self.assertIn("\t", root.find("node").get("TEXT"))
+
+    # =========================================================================
+    # Very long node labels
+    # =========================================================================
+
+    def test_very_long_node_label_plantuml(self):
+        """A node label with 10000 characters is handled correctly."""
+        long_text = "A" * 10000
+        puml = f"@startmindmap\n* {long_text}\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        self.assertEqual(root.find("node").get("TEXT"), long_text)
+
+    def test_very_long_label_in_freemind_xml(self):
+        """A Freemind node with 10000 character TEXT is converted correctly."""
+        long_text = "X" * 10000
+        xml_content = f'<map version="freeplane 1.9.13"><node TEXT="{long_text}"/></map>'
+        result = self.converter.freemind_to_plantuml(xml_content)
+        self.assertIn(long_text, result)
+
+    def test_many_siblings_at_same_level(self):
+        """100 siblings at the same level are handled."""
+        children = "\n".join(["* Child" + str(i) for i in range(100)])
+        puml = f"@startmindmap\n* Root\n{children}\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        siblings = root_node.findall("node")
+        self.assertEqual(len(siblings), 100)
+        for i in range(100):
+            self.assertEqual(siblings[i].get("TEXT"), f"Child{i}")
+
+    # =========================================================================
+    # Mixed line endings
+    # =========================================================================
+
+    def test_plantuml_with_crlf_line_endings(self):
+        """PlantUML with \\r\\n (Windows) line endings is parsed correctly."""
+        puml = "@startmindmap\r\n* Root\r\n** Child 1\r\n** Child 2\r\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        children = root_node.findall("node")
+        self.assertEqual(len(children), 2)
+
+    def test_plantuml_with_cr_only_line_endings(self):
+        """PlantUML with \\r (old Mac) line endings is parsed correctly."""
+        # This tests how split('\\n') handles \\r-only line endings
+        puml = "@startmindmap\r* Root\r** Child\r@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        child = root_node.find("node")
+        self.assertEqual(child.get("TEXT"), "Child")
+
+    def test_plantuml_with_mixed_line_endings(self):
+        """PlantUML with mixed \\r\\n and \\n line endings is parsed correctly."""
+        puml = "@startmindmap\r\n* Root\r\n** Child 1\r** Child 2\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        children = root_node.findall("node")
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "Child 1")
+        self.assertEqual(children[1].get("TEXT"), "Child 2")
+
+    # =========================================================================
+    # parse_plantuml_line edge cases (direct unit tests)
+    # =========================================================================
+
+    def test_parse_plantuml_line_basic_star(self):
+        """Basic single-asterisk node parsing."""
+        result = self.converter.parse_plantuml_line("* Root")
+        self.assertEqual(result, (1, "Root", False))
+
+    def test_parse_plantuml_line_multiple_stars(self):
+        """Triple-asterisk node parsing."""
+        result = self.converter.parse_plantuml_line("*** Deep")
+        self.assertEqual(result, (3, "Deep", False))
+
+    def test_parse_plantuml_line_legacy_underscore(self):
+        """Legacy *_ syntax is parsed correctly."""
+        result = self.converter.parse_plantuml_line("*_ Root")
+        self.assertEqual(result, (1, "Root", False))
+
+    def test_parse_plantuml_line_multiline_start(self):
+        """Single-colon notation marks as multiline start."""
+        result = self.converter.parse_plantuml_line("* :text with colons;")
+        self.assertEqual(result, (1, "text with colons;", True))
+
+    def test_parse_plantuml_line_non_node_returns_none(self):
+        """Non-node lines (comments, markers, blank) return None."""
+        self.assertIsNone(self.converter.parse_plantuml_line("' comment"))
+        self.assertIsNone(self.converter.parse_plantuml_line("@startmindmap"))
+        self.assertIsNone(self.converter.parse_plantuml_line("not a node"))
+
+    def test_parse_plantuml_line_stripped_whitespace(self):
+        """Lines with leading whitespace are matched."""
+        result = self.converter.parse_plantuml_line("  ** Indented Child")
+        self.assertEqual(result, (2, "Indented Child", False))
+
+    def test_parse_plantuml_line_empty_text_after_stars(self):
+        """Asterisks with nothing after them yield empty text."""
+        result = self.converter.parse_plantuml_line("* ")
+        self.assertEqual(result, (1, "", False))
+
+    def test_parse_plantuml_line_colon_only(self):
+        """A line like `* :` is parsed as multiline start with empty text."""
+        result = self.converter.parse_plantuml_line("* :")
+        self.assertEqual(result, (1, "", True))
+
+    # =========================================================================
+    # create_xml_node edge cases
+    # =========================================================================
+
+    def test_create_xml_node_with_link(self):
+        """A note with a [[url label]] hyperlink creates a hook element."""
+        parent = ET.Element("map")
+        node = self.converter.create_xml_node(parent, "[[http://example.com Example]]")
+        # The [[url label]] form replaces the whole block with just the label
+        self.assertEqual(node.get("TEXT"), "Example")
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://example.com")
+
+    def test_create_xml_node_with_url_only_link(self):
+        """A [[url]] form without label sets text and URI to the URL."""
+        parent = ET.Element("map")
+        node = self.converter.create_xml_node(parent, "[[http://example.com]]")
+        self.assertEqual(node.get("TEXT"), "http://example.com")
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://example.com")
+
+    def test_create_xml_node_no_link(self):
+        """A node without any link has no hook element."""
+        parent = ET.Element("map")
+        node = self.converter.create_xml_node(parent, "Plain text")
+        self.assertEqual(node.get("TEXT"), "Plain text")
+        self.assertIsNone(node.find("hook"))
+
+    def test_create_xml_node_empty_text(self):
+        """A node with empty TEXT is created properly."""
+        parent = ET.Element("map")
+        node = self.converter.create_xml_node(parent, "")
+        self.assertEqual(node.get("TEXT"), "")
+        self.assertEqual(node.get("FOLDED"), "false")
+
+    # =========================================================================
+    # Additional edge cases for converter behavior
+    # =========================================================================
+
+    def test_plantuml_with_only_whitespace_between_markers(self):
+        """Only whitespace between @startmindmap and @endmindmap yields no nodes."""
+        puml = "@startmindmap\n  \n \n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        self.assertEqual(len(root.findall("node")), 0)
+
+    def test_freemind_to_plantuml_node_tag_as_root(self):
+        """Freemind with <node> as root element converts correctly."""
+        xml_content = '<node TEXT="Root"><node TEXT="Child"/></node>'
+        puml = self.converter.freemind_to_plantuml(xml_content)
+        self.assertIn("* Root", puml)
+        self.assertIn("** Child", puml)
+
+    def test_freemind_to_plantuml_unexpected_root_tag(self):
+        """Freemind with unknown root tag produces only markers (no nodes)."""
+        xml_content = '<unexpected><node TEXT="Ignored"/></unexpected>'
+        puml = self.converter.freemind_to_plantuml(xml_content)
+        self.assertEqual(puml.strip(), "@startmindmap\n@endmindmap")
+
+    def test_freemind_to_markdown_unexpected_root_tag(self):
+        """Freemind with unknown root tag produces an empty string."""
+        xml_content = '<unexpected><node TEXT="Ignored"/></unexpected>'
+        result = self.converter.freemind_to_markdown(xml_content)
+        self.assertEqual(result, "")
+
+    def test_multiple_nodes_at_root_level_markdown(self):
+        """Multiple root-level nodes in Markdown: only the first H1 is used."""
+        md = "# Root\n- Child 1\n# Ignored Header\n- Child 2"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        children = root_node.findall("node")
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "Child 1")
+        self.assertEqual(children[1].get("TEXT"), "Child 2")
+
+    def test_plantuml_node_with_only_asterisks(self):
+        """A line with just asterisks and no text produces a valid (empty TEXT) node."""
+        puml = "@startmindmap\n*****\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertIsNotNone(root_node)
+        self.assertEqual(root_node.get("TEXT"), "")
+
+    def test_emoji_roundtrip_plantuml_to_freemind(self):
+        """Emojis survive the full PlantUML -> Freemind -> PlantUML roundtrip."""
+        original = "@startmindmap\n* 🌳 Tree\n** 🍃 Leaf\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(original)
+        roundtripped = self.converter.freemind_to_plantuml(xml)
+        self.assertIn("🌳 Tree", roundtripped)
+        self.assertIn("🍃 Leaf", roundtripped)
+
+    def test_plantuml_with_bracket_characters_in_text(self):
+        """Brackets in node text that don't form valid links are preserved."""
+        puml = "@startmindmap\n* [text] (not a link)\n@endmindmap"
+        xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "[text] (not a link)")
+
+    def test_freemind_with_node_missing_text_attribute(self):
+        """Freemind node without TEXT attribute defaults to empty string."""
+        xml_content = '<map version="freeplane 1.9.13"><node><node TEXT="Child"/></node></map>'
+        puml = self.converter.freemind_to_plantuml(xml_content)
+        # The root node should have empty text
+        self.assertIn("* ", puml)
+        self.assertIn("** Child", puml)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds 37 new edge case tests to `test_additional_edge_cases.py` in 8 test classes:

### Tests Added
- **TestMainCLI** (9 tests): CLI entry point coverage — `--to-md`, `--from-md`, `-o` output file, error exits
- **TestMultipleRootNodes** (3 tests): Freemind with multiple top-level nodes
- **TestCreateXmlNodeEdgeCases** (5 tests): `create_xml_node` link extraction edge cases, malformed patterns
- **TestFreemindToMarkdownEdgeCases** (4 tests): Conversion edge cases
- **TestMarkdownToFreemindEdgeCases** (5 tests): Regex behavior, ignored lines, link edge cases
- **TestPlantumlToFreemindEdgeCases** (6 tests): Multiple roots, complex nesting, bracket patterns
- **TestFreemindToPlantumlEdgeCases** (3 tests): Empty maps, multiple hooks
- **TestRoundtripEdgeCases** (2 tests): Multi-root and multiline roundtrips

### Coverage Gaps Filled
- `main()` CLI function was completely untested
- `create_xml_node()` link extraction had no unit tests
- Multiple top-level nodes in Freemind → PlantUML conversion
- Markdown regex edge cases with special characters in link text

### Pre-existing Issues Found
Also committed `test_edge_cases.py` (created by prior heartbeat run) which uncovered 3 bugs:
- CR-only line endings not handled
- 100 siblings at same level not handled
- Mixed line endings (`\r\n` + `\n`) not handled

### Test Results
- 37 new tests: **all passing** ✅
- 41 core tests (test_mindmapconverter): **all passing** ✅
- 51 pre-existing edge case tests (test_edge_cases.py): 48 passing, 3 failing (pre-existing bugs)