### PR TITLE
fix: normalize line endings and correct siblings test

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -184,6 +184,9 @@ class MindMapConverter:
 
     def plantuml_to_freemind(self, plantuml_string: str) -> str:
         """Convert a PlantUML mindmap string to Freemind/Freeplane XML."""
+        # Normalize line endings (\r\n from Windows, \r from legacy Mac) to \n
+        # so split("\n") produces one logical line per source line.
+        plantuml_string = plantuml_string.replace("\r\n", "\n").replace("\r", "\n")
         lines = plantuml_string.strip().split("\n")
         stripped_lines = [line.strip() for line in lines]
         try:
@@ -316,6 +319,7 @@ class MindMapConverter:
         Raises:
             ValueError: If no H1 header is found in the content.
         """
+        content = content.replace("\r\n", "\n").replace("\r", "\n")
         lines = content.split("\n")
 
         root = ET.Element("map")

--- a/test_edge_cases.py
+++ b/test_edge_cases.py
@@ -281,8 +281,8 @@ class TestMindMapConverterEdgeCases(unittest.TestCase):
         self.assertIn(long_text, result)
 
     def test_many_siblings_at_same_level(self):
-        """100 siblings at the same level are handled."""
-        children = "\n".join(["* Child" + str(i) for i in range(100)])
+        """100 siblings at level 2 under a single root are handled."""
+        children = "\n".join(["** Child" + str(i) for i in range(100)])
         puml = f"@startmindmap\n* Root\n{children}\n@endmindmap"
         xml_output = self.converter.plantuml_to_freemind(puml)
         root = ET.fromstring(xml_output)
@@ -321,6 +321,30 @@ class TestMindMapConverterEdgeCases(unittest.TestCase):
         """PlantUML with mixed \\r\\n and \\n line endings is parsed correctly."""
         puml = "@startmindmap\r\n* Root\r\n** Child 1\r** Child 2\n@endmindmap"
         xml_output = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        children = root_node.findall("node")
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "Child 1")
+        self.assertEqual(children[1].get("TEXT"), "Child 2")
+
+    def test_markdown_with_crlf_line_endings(self):
+        """Markdown with \\r\\n (Windows) line endings is parsed correctly."""
+        md = "# Root\r\n- Child 1\r\n- Child 2\r\n"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        root_node = root.find("node")
+        self.assertEqual(root_node.get("TEXT"), "Root")
+        children = root_node.findall("node")
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0].get("TEXT"), "Child 1")
+        self.assertEqual(children[1].get("TEXT"), "Child 2")
+
+    def test_markdown_with_cr_only_line_endings(self):
+        """Markdown with \\r (old Mac) line endings is parsed correctly."""
+        md = "# Root\r- Child 1\r- Child 2\r"
+        xml_output = self.converter.markdown_to_freemind(md)
         root = ET.fromstring(xml_output)
         root_node = root.find("node")
         self.assertEqual(root_node.get("TEXT"), "Root")


### PR DESCRIPTION
## Summary

Fixes the three pre-existing failures called out in PR #23.

### Bug 1 & 2: Line-ending handling

`plantuml_to_freemind` and `markdown_to_freemind` both split on `\n`. That breaks on two shapes:

- **CR-only (legacy Mac)** — e.g. `"@startmindmap\r* Root\r@endmindmap"` becomes a single "line" with no `\n`, so the parser throws `"missing @startmindmap or @endmindmap"`.
- **Mixed `\r\n` + `\r`** — a bare `\r` inside an otherwise-`\n` stream leaves two logical lines glued into one, silently losing nodes.

Fix: normalize `\r\n` → `\n` and then `\r` → `\n` before splitting. Same fix applied to both converters. CRLF already worked (trailing `\r` was handled by `line.strip()` in the PlantUML path), but the normalization makes the two converters behave consistently.

### Bug 3: `test_many_siblings_at_same_level`

The test built `* Root\n* Child0\n* Child1\n…` — all at level 1. After the sibling-attachment fix in PR #22, those `* ChildN` lines become separate roots under `<map>` (consistent with `test_multiple_root_nodes_in_plantuml` in `test_additional_edge_cases.py`), not children of Root. The assertion `len(root_node.findall("node")) == 100` could never hold.

Fix: change the data to `** ChildN` so the 100 nodes are true children of Root — matching the test's name ("many siblings at the same level") and its assertion.

### Regression tests

Added `test_markdown_with_crlf_line_endings` and `test_markdown_with_cr_only_line_endings` to pin down the markdown-side normalization.

## Test plan

- [x] `python3 -m unittest test_edge_cases.py test_mindmapconverter.py test_additional_edge_cases.py` — 131 tests pass (was 128 passing + 3 failing).