### PR TITLE
fix: preserve ';' at end of line in multiline node text on round-trip

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -152,6 +152,21 @@ class MindMapConverter:
             return level, text, is_multiline_start
         return None
 
+    def _is_multiline_terminator(self, lines: List[str], line_idx: int, end_idx: int) -> bool:
+        """Return True if the `;` at the end of ``lines[line_idx]`` terminates a multi-line node.
+
+        A trailing `;` is the real terminator when the next non-empty line is a new node
+        marker, a comment, a meta directive, or end-of-content. Otherwise the `;` is
+        internal to the node's text and multi-line collection should continue.
+        """
+        peek_i = line_idx + 1
+        while peek_i < end_idx and not lines[peek_i].strip():
+            peek_i += 1
+        if peek_i >= end_idx:
+            return True
+        stripped = lines[peek_i].strip()
+        return stripped.startswith("*") or stripped.startswith("'") or stripped.startswith("@")
+
     def create_xml_node(self, parent: ET.Element, text: str) -> ET.Element:
         """Create a Freemind XML node under parent, extracting any [[url label]] hyperlink."""
         # Extract the first [[url label]] or [[url]] hyperlink; only one URI per node is supported.
@@ -218,21 +233,22 @@ class MindMapConverter:
                 i_advanced = False
 
                 if is_multiline_start:
-                    if text.endswith(";"):
-                        # Single-line form: `:text;` — strip the semicolon
+                    # A trailing `;` is the multiline terminator only when followed by a
+                    # new node/comment/meta directive or EOF. Otherwise it is internal
+                    # to the node's text; this preserves `;\n` mid-text on round-trip.
+                    if text.endswith(";") and self._is_multiline_terminator(lines, i, end_idx):
                         text = text[:-1]
                     else:
-                        # Multi-line form: read continuation lines until one ends with ;
                         multiline_text = [text]
                         i += 1
                         while i < end_idx:
-                            next_line = lines[i].strip()
-                            if next_line.endswith(";"):
-                                multiline_text.append(next_line[:-1])
+                            current_line = lines[i].strip()
+                            if current_line.endswith(";") and self._is_multiline_terminator(lines, i, end_idx):
+                                multiline_text.append(current_line[:-1])
                                 i += 1
                                 break
                             else:
-                                multiline_text.append(lines[i].strip())
+                                multiline_text.append(current_line)
                                 i += 1
                         else:
                             raise ValueError(

--- a/test_additional_edge_cases.py
+++ b/test_additional_edge_cases.py
@@ -498,5 +498,83 @@ class TestRoundtripEdgeCases(unittest.TestCase):
         self.assertIn("Line 2", roundtripped)
 
 
+class TestMultilineSemicolonHandling(unittest.TestCase):
+    """Regression tests for multi-line node text whose lines contain ';'.
+
+    The PlantUML multi-line form is ``:text;`` where ``;`` is the terminator.
+    When a Freemind node's TEXT contains a ``;`` at the end of a non-last
+    line, the naive serialisation ``:line1;\\nline2;`` is ambiguous with the
+    single-line form followed by orphan content. The parser resolves the
+    ambiguity by looking at the line following a trailing ``;``: if it is a
+    new node / comment / meta directive (or EOF) the ``;`` is a terminator,
+    otherwise it is internal to the node's text.
+    """
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_roundtrip_preserves_semicolon_at_end_of_first_line(self):
+        """Freemind text ``'Line 1;\\nLine 2'`` must round-trip through PlantUML intact."""
+        xml = ('<map version="freeplane 1.9.13">'
+               '<node TEXT="Line 1;&#10;Line 2"/></map>')
+        puml = self.converter.freemind_to_plantuml(xml)
+        roundtripped = self.converter.plantuml_to_freemind(puml)
+        node = ET.fromstring(roundtripped).find("node")
+        self.assertEqual(node.get("TEXT"), "Line 1;\nLine 2")
+
+    def test_roundtrip_preserves_semicolons_on_all_intermediate_lines(self):
+        """Every intermediate line ending with ``;`` is preserved (only the last ``;`` is the terminator)."""
+        xml = ('<map version="freeplane 1.9.13">'
+               '<node TEXT="a;&#10;b;&#10;c"/></map>')
+        puml = self.converter.freemind_to_plantuml(xml)
+        roundtripped = self.converter.plantuml_to_freemind(puml)
+        node = ET.fromstring(roundtripped).find("node")
+        self.assertEqual(node.get("TEXT"), "a;\nb;\nc")
+
+    def test_single_line_colon_form_still_strips_terminator(self):
+        """``** :text;`` followed by a new node still parses as a single-line multiline."""
+        puml = "@startmindmap\n* Root\n** :single;\n* NewRoot\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        root = ET.fromstring(xml)
+        roots = root.findall("node")
+        self.assertEqual(len(roots), 2)
+        self.assertEqual(roots[0].get("TEXT"), "Root")
+        child = roots[0].find("node")
+        self.assertEqual(child.get("TEXT"), "single")
+        self.assertEqual(roots[1].get("TEXT"), "NewRoot")
+
+    def test_single_line_colon_form_before_endmindmap(self):
+        """``** :text;`` immediately followed by ``@endmindmap`` parses as single-line."""
+        puml = "@startmindmap\n* Root\n** :single;\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        child = ET.fromstring(xml).find("node").find("node")
+        self.assertEqual(child.get("TEXT"), "single")
+
+    def test_single_line_colon_form_before_comment(self):
+        """``** :text;`` followed by a comment parses as single-line."""
+        puml = "@startmindmap\n* Root\n** :single;\n' a comment\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        child = ET.fromstring(xml).find("node").find("node")
+        self.assertEqual(child.get("TEXT"), "single")
+
+    def test_multiline_with_internal_semicolon_parses_across_all_lines(self):
+        """A multi-line where continuation lines end with ``;`` keeps reading until a real terminator."""
+        puml = "@startmindmap\n* Root\n** :a;\nb;\nc;\n@endmindmap"
+        xml = self.converter.plantuml_to_freemind(puml)
+        child = ET.fromstring(xml).find("node").find("node")
+        self.assertEqual(child.get("TEXT"), "a;\nb;\nc")
+
+    def test_unterminated_multiline_with_internal_semicolon_still_raises(self):
+        """An ambiguous multi-line whose `;` lines are all non-terminators raises ValueError.
+
+        Without a blocking marker / EOF, every trailing ``;`` is absorbed as internal; so
+        the multi-line never terminates and the existing error is raised.
+        """
+        puml = "@startmindmap\n* Root\n** :a;\nb\n@endmindmap"
+        with self.assertRaises(ValueError) as ctx:
+            self.converter.plantuml_to_freemind(puml)
+        self.assertIn("Unterminated", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in the Freemind → PlantUML → Freemind round-trip: any node whose TEXT contained a `;` at the end of a non-last line had the tail of its multi-line text silently discarded.

### Reproduction (before the fix)

```python
xml = '<map version="v"><node TEXT="Line 1;&#10;Line 2"/></map>'
puml = c.freemind_to_plantuml(xml)      # "** :Line 1;\nLine 2;"
rt   = c.plantuml_to_freemind(puml)
# TEXT of the round-tripped node is "Line 1" — "Line 2" was dropped.
```

### Root cause

PlantUML's mindmap multi-line form is `* :line1\nline2;` with `;` as the terminator. The serializer happily emits `:Line 1;\nLine 2;` but the parser saw the first `;` and treated the node as the single-line form `:text;`, leaving `Line 2;` as an orphan that matched nothing and was skipped.

### Fix

`plantuml_to_freemind` now disambiguates a trailing `;` by peeking at the next non-empty line:

- If that line is a new node marker (`*`), a comment (`'`), a meta directive (`@`) or EOF → the `;` is the real terminator (existing behaviour).
- Otherwise → the `;` is internal to the node's text and the multi-line collector keeps going until a real terminator is reached.

A new helper `_is_multiline_terminator` encapsulates the peek.

### Behaviour preserved

- Single-line `* :text;` still strips the terminator.
- Multi-line forms without an internal `;` are unchanged.
- Genuinely unterminated multi-lines still raise `ValueError("Unterminated multiline node: missing closing ';'.")`.

## Test plan

- [x] `python3 -m unittest discover -s . -p "test_*.py"` — **138 tests pass** (131 existing + 7 new)
- [x] New `TestMultilineSemicolonHandling` class in `test_additional_edge_cases.py` covers:
  - Round-trip of `Line 1;\nLine 2` preserves the embedded `;\n`
  - Round-trip of `a;\nb;\nc` preserves every intermediate `;`
  - `** :single;` followed by a new node still parses as single-line
  - `** :single;` followed by `@endmindmap` still parses as single-line
  - `** :single;` followed by a `'` comment still parses as single-line
  - Multi-line `** :a;\nb;\nc;` parses to `a;\nb;\nc`
  - Unterminated multi-line still raises `ValueError`
- [x] Manual spot-check of the original failing input now round-trips correctly.
