### PR TITLE
fix: preserve balanced parens in Markdown link URLs

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -268,6 +268,41 @@ class MindMapConverter:
 
         return ET.tostring(root, encoding="unicode", method="xml")
 
+    @staticmethod
+    def _find_markdown_link(text: str) -> Optional[Tuple[int, int, str, str]]:
+        """Locate the first ``[label](url)`` link with balanced parens in the URL.
+
+        Standard Markdown allows unescaped parentheses inside a link URL as long
+        as they are balanced (CommonMark 6.3), which is common for e.g.
+        Wikipedia disambiguation URLs such as
+        ``https://en.wikipedia.org/wiki/Python_(programming_language)``. A naive
+        ``\\(([^)]+)\\)`` regex truncates those URLs at the first ``)``; this
+        helper walks the string and matches parens explicitly.
+
+        Returns ``(start, end, label, url)`` spans relative to ``text`` where
+        ``text[start:end]`` is the full ``[label](url)`` substring, or ``None``
+        if no well-formed link is found.
+        """
+        bracket_match = re.search(r"\[([^\]]+)\]\(", text)
+        if not bracket_match:
+            return None
+
+        label = bracket_match.group(1)
+        url_start = bracket_match.end()
+        depth = 1
+        pos = url_start
+        while pos < len(text):
+            ch = text[pos]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    url = text[url_start:pos]
+                    return bracket_match.start(), pos + 1, label, url
+            pos += 1
+        return None
+
     def _create_md_xml_node(self, parent: ET.Element, text: str) -> ET.Element:
         """Create a Freemind XML node from Markdown text, extracting ``[text](url)`` links.
 
@@ -280,12 +315,11 @@ class MindMapConverter:
         """
         uri = None
 
-        # Extract markdown link [text](url)
-        link_match = re.search(r"\[([^\]]+)\]\(([^)]+)\)", text)
-        if link_match:
-            label = link_match.group(1)
-            url = link_match.group(2)
-            text = text[:link_match.start()] + label + text[link_match.end():]
+        # Extract markdown link [text](url); supports balanced parens in the URL.
+        link = self._find_markdown_link(text)
+        if link:
+            start, end, label, url = link
+            text = text[:start] + label + text[end:]
             uri = url
 
         # Convert <br> back to newlines

--- a/test_additional_edge_cases.py
+++ b/test_additional_edge_cases.py
@@ -498,5 +498,99 @@ class TestRoundtripEdgeCases(unittest.TestCase):
         self.assertIn("Line 2", roundtripped)
 
 
+class TestMarkdownLinkBalancedParens(unittest.TestCase):
+    """Tests for Markdown links whose URLs contain balanced parentheses.
+
+    CommonMark allows unescaped parens inside a link URL as long as they are
+    balanced. The naive ``\\[([^\\]]+)\\]\\(([^)]+)\\)`` regex truncates the URL
+    at the first ``)`` and corrupts the node text, which broke common URLs such
+    as Wikipedia disambiguation links. These tests pin down the corrected
+    behaviour and guard against regressions.
+    """
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_wikipedia_disambiguation_url_preserved(self):
+        """URL with a single (...) segment (Wikipedia-style) is preserved."""
+        md = (
+            "# Root\n"
+            "- [Python](https://en.wikipedia.org/wiki/Python_(programming_language))"
+        )
+        xml = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml)
+        python_node = root.find("node").find("node")
+
+        self.assertEqual(python_node.get("TEXT"), "Python")
+        hook = python_node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(
+            hook.get("URI"),
+            "https://en.wikipedia.org/wiki/Python_(programming_language)",
+        )
+
+    def test_url_with_parens_survives_md_roundtrip(self):
+        """MD → XML → MD → XML roundtrip preserves a paren-containing URL."""
+        md = (
+            "# Root\n"
+            "- [Python](https://en.wikipedia.org/wiki/Python_(programming_language))\n"
+            "- Plain"
+        )
+        xml = self.converter.markdown_to_freemind(md)
+        md_back = self.converter.freemind_to_markdown(xml)
+        xml_roundtrip = self.converter.markdown_to_freemind(md_back)
+        self.assertEqual(xml, xml_roundtrip)
+
+    def test_url_with_nested_balanced_parens(self):
+        """URL with nested balanced parens like /foo(bar(baz))/ parses correctly."""
+        md = "# Root\n- [label](http://example.com/foo(bar(baz))/path)"
+        xml = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml)
+        child = root.find("node").find("node")
+
+        self.assertEqual(child.get("TEXT"), "label")
+        self.assertEqual(
+            child.find("hook").get("URI"),
+            "http://example.com/foo(bar(baz))/path",
+        )
+
+    def test_plain_url_without_parens_still_works(self):
+        """Regression guard: simple URLs continue to parse correctly."""
+        md = "# Root\n- [docs](http://example.com/page)"
+        xml = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml)
+        child = root.find("node").find("node")
+
+        self.assertEqual(child.get("TEXT"), "docs")
+        self.assertEqual(
+            child.find("hook").get("URI"), "http://example.com/page"
+        )
+
+    def test_unbalanced_parens_leaves_link_as_text(self):
+        """Link with unbalanced parens (no matching ``)``) is not treated as a link."""
+        md = "# Root\n- [bad](http://example.com/unclosed"
+        xml = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml)
+        child = root.find("node").find("node")
+
+        # No hook should be created; the literal text is preserved verbatim.
+        self.assertIsNone(child.find("hook"))
+        self.assertEqual(child.get("TEXT"), "[bad](http://example.com/unclosed")
+
+    def test_find_markdown_link_returns_none_for_plain_text(self):
+        """``_find_markdown_link`` returns None when no link is present."""
+        self.assertIsNone(self.converter._find_markdown_link("just plain text"))
+
+    def test_find_markdown_link_returns_spans_and_parts(self):
+        """``_find_markdown_link`` returns correct spans, label, and url."""
+        text = "see [a](http://x.com/y) now"
+        result = self.converter._find_markdown_link(text)
+        self.assertIsNotNone(result)
+        start, end, label, url = result
+        self.assertEqual(text[start:end], "[a](http://x.com/y)")
+        self.assertEqual(label, "a")
+        self.assertEqual(url, "http://x.com/y")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in `markdown_to_freemind`: any Markdown link whose URL contains an unescaped paren pair (very common — Wikipedia disambiguation URLs, JIRA filters, etc.) is truncated at the first `)`.

### Reproduction (before the fix)

```python
from mindmapconverter import MindMapConverter
c = MindMapConverter()
md = "# Root\n- [Python](https://en.wikipedia.org/wiki/Python_(programming_language))"
print(c.markdown_to_freemind(md))
```

Produces:

```xml
<node TEXT="Python)"><hook URI="https://en.wikipedia.org/wiki/Python_(programming_language" /></node>
```

The `)` that should close the URL is misread as part of the node label, and the URL loses its final `)`.

### Root cause

`_create_md_xml_node` used `re.search(r"\[([^\]]+)\]\(([^)]+)\)")`. The URL group `[^)]+` stops at the first `)`, so any URL containing a nested paren is truncated. CommonMark §6.3 allows unescaped parens inside link destinations as long as they are balanced — this PR brings the parser in line with that rule.

### Fix

New helper `MindMapConverter._find_markdown_link` locates the `[label](` opener via regex, then walks the remainder of the string tracking paren depth. The URL ends when depth returns to zero; if depth never balances, the helper returns `None` and the link is left as literal text rather than being misparsed.

### Behaviour preserved

- Plain URLs without parens still parse identically.
- Unbalanced `[label](http://...` input is no longer half-parsed — it is preserved verbatim as text.
- `freemind_to_markdown` → `markdown_to_freemind` is now a true roundtrip for paren-containing URIs.

## Test plan

- [x] `python3 -m unittest test_mindmapconverter test_edge_cases test_additional_edge_cases` — **138 tests pass** (131 existing + 7 new).
- [x] New `TestMarkdownLinkBalancedParens` class covers:
  - Wikipedia-style single-paren URL
  - MD → XML → MD → XML roundtrip equality
  - Nested balanced parens (`/foo(bar(baz))/`)
  - Plain URL regression guard
  - Unbalanced `)` left as literal text
  - Direct unit tests for the `_find_markdown_link` helper


---
_Generated by [Claude Code](https://claude.ai/code/session_015G3BsWPU3K3z5EGcNjkz7Y)_