### PR TITLE
fix: support balanced brackets in Markdown link labels

### DIFF
--- a/mindmapconverter.py
+++ b/mindmapconverter.py
@@ -270,37 +270,59 @@ class MindMapConverter:
 
     @staticmethod
     def _find_markdown_link(text: str) -> Optional[Tuple[int, int, str, str]]:
-        """Locate the first ``[label](url)`` link with balanced parens in the URL.
+        """Locate the first ``[label](url)`` link with balanced brackets in the
+        label and balanced parens in the URL.
 
-        Standard Markdown allows unescaped parentheses inside a link URL as long
-        as they are balanced (CommonMark 6.3), which is common for e.g.
-        Wikipedia disambiguation URLs such as
-        ``https://en.wikipedia.org/wiki/Python_(programming_language)``. A naive
-        ``\\(([^)]+)\\)`` regex truncates those URLs at the first ``)``; this
-        helper walks the string and matches parens explicitly.
+        CommonMark (6.3) allows unescaped parentheses inside a link URL as long
+        as they are balanced, which is common for e.g. Wikipedia disambiguation
+        URLs such as ``https://en.wikipedia.org/wiki/Python_(programming_language)``.
+        Similarly, link text may contain balanced brackets (for programming-style
+        identifiers like ``array[0]`` or footnote-like markers). A naive
+        ``\\[([^\\]]+)\\]\\(([^)]+)\\)`` regex truncates URLs at the first ``)``
+        and refuses any ``]`` inside the label; this helper walks the string
+        and matches both bracket types explicitly.
 
         Returns ``(start, end, label, url)`` spans relative to ``text`` where
         ``text[start:end]`` is the full ``[label](url)`` substring, or ``None``
         if no well-formed link is found.
         """
-        bracket_match = re.search(r"\[([^\]]+)\]\(", text)
-        if not bracket_match:
-            return None
-
-        label = bracket_match.group(1)
-        url_start = bracket_match.end()
-        depth = 1
-        pos = url_start
-        while pos < len(text):
-            ch = text[pos]
-            if ch == "(":
-                depth += 1
-            elif ch == ")":
-                depth -= 1
-                if depth == 0:
-                    url = text[url_start:pos]
-                    return bracket_match.start(), pos + 1, label, url
-            pos += 1
+        n = len(text)
+        i = 0
+        while i < n:
+            if text[i] != "[":
+                i += 1
+                continue
+            # Walk to the matching closing ']' with balanced nesting.
+            depth = 1
+            j = i + 1
+            while j < n:
+                c = text[j]
+                if c == "[":
+                    depth += 1
+                elif c == "]":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            # Unbalanced '[' or no '(' immediately after ']'; skip this start.
+            if depth != 0 or j + 1 >= n or text[j + 1] != "(":
+                i += 1
+                continue
+            label = text[i + 1:j]
+            url_start = j + 2
+            pdepth = 1
+            pos = url_start
+            while pos < n:
+                c = text[pos]
+                if c == "(":
+                    pdepth += 1
+                elif c == ")":
+                    pdepth -= 1
+                    if pdepth == 0:
+                        return i, pos + 1, label, text[url_start:pos]
+                pos += 1
+            # Unbalanced URL parens; advance past this candidate and keep looking.
+            i += 1
         return None
 
     def _create_md_xml_node(self, parent: ET.Element, text: str) -> ET.Element:

--- a/test_additional_edge_cases.py
+++ b/test_additional_edge_cases.py
@@ -337,16 +337,31 @@ class TestMarkdownToFreemindEdgeCases(unittest.TestCase):
         self.assertEqual(root.find("node").get("TEXT"), "Root")
         self.assertEqual(len(root.find("node").findall("node")), 0)
 
-    def test_link_text_with_bracket_chars_not_extracted(self):
-        """Markdown link text containing ] chars: regex cannot match, text is preserved as-is."""
+    def test_link_text_with_balanced_bracket_chars_extracted(self):
+        """Markdown link text containing balanced [] is extracted per CommonMark."""
         md = "# Root\n- [A.B*C+?|()[] Test](http://example.com)"
         xml_output = self.converter.markdown_to_freemind(md)
         root = ET.fromstring(xml_output)
         node = root.find("node").find("node")
-        # The regex r'\[([^\]]+)\]\(([^)]+)\)' fails when the link text contains ']'
-        # So the entire bracket expression is kept as raw TEXT
-        self.assertEqual(node.get("TEXT"), "[A.B*C+?|()[] Test](http://example.com)")
-        self.assertIsNone(node.find("hook"))
+        # CommonMark 6.3 permits balanced brackets inside link text, so the
+        # outer [...] wraps a label that itself contains the balanced "[]" pair.
+        self.assertEqual(node.get("TEXT"), "A.B*C+?|()[] Test")
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://example.com")
+
+    def test_link_text_with_unbalanced_bracket_not_extracted(self):
+        """Unbalanced '[' in link text means the outer expression isn't a link."""
+        md = "# Root\n- [label with [ unbalanced](http://example.com)"
+        xml_output = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(xml_output)
+        node = root.find("node").find("node")
+        # The inner '[' is unbalanced against the outer ']', so the scanner
+        # falls through to the inner '[' and extracts that as the link start.
+        self.assertEqual(node.get("TEXT"), "[label with  unbalanced")
+        hook = node.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://example.com")
 
     def test_multiline_text_with_br_in_markdown_input(self):
         """Multiple <br> tags in Markdown convert to actual newlines."""
@@ -642,6 +657,49 @@ class TestMarkdownLinkBalancedParens(unittest.TestCase):
         self.assertEqual(text[start:end], "[a](http://x.com/y)")
         self.assertEqual(label, "a")
         self.assertEqual(url, "http://x.com/y")
+
+
+class TestMarkdownLinkBalancedBrackets(unittest.TestCase):
+    """Tests for Markdown links whose label text contains balanced brackets.
+
+    CommonMark 6.3 permits balanced ``[]`` inside link text. This matters for
+    round-tripping .mm -> .md -> .mm whenever a node's TEXT contains ``[`` or
+    ``]`` (e.g. programming identifiers like ``array[0]``), since the naive
+    ``[^\\]]+`` regex would otherwise drop the link on the return trip.
+    """
+
+    def setUp(self):
+        self.converter = MindMapConverter()
+
+    def test_label_with_balanced_inner_brackets(self):
+        """Label with nested ``[0]`` is extracted with the full label intact."""
+        text = "[array[0]](http://x.com)"
+        result = self.converter._find_markdown_link(text)
+        self.assertIsNotNone(result)
+        start, end, label, url = result
+        self.assertEqual(text[start:end], "[array[0]](http://x.com)")
+        self.assertEqual(label, "array[0]")
+        self.assertEqual(url, "http://x.com")
+
+    def test_roundtrip_mm_to_md_to_mm_preserves_link_with_brackets(self):
+        """.mm -> .md -> .mm round-trip preserves both TEXT and hook URI when
+        the node text contains balanced brackets."""
+        mm_input = (
+            '<map version="freeplane 1.9.13">'
+            '<node TEXT="Root" FOLDED="false">'
+            '<node TEXT="array[0]" FOLDED="false">'
+            '<hook NAME="ExternalObject" URI="http://example.com/a"/>'
+            '</node></node></map>'
+        )
+        md = self.converter.freemind_to_markdown(mm_input)
+        mm_out = self.converter.markdown_to_freemind(md)
+        root = ET.fromstring(mm_out)
+        child = root.find("node").find("node")
+
+        self.assertEqual(child.get("TEXT"), "array[0]")
+        hook = child.find("hook")
+        self.assertIsNotNone(hook)
+        self.assertEqual(hook.get("URI"), "http://example.com/a")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes a round-trip bug in Markdown link parsing where node text containing `[` or `]` (e.g. programming identifiers like `array[0]`) silently lost its hyperlink on `.mm -> .md -> .mm` conversion.

## Root cause

`_find_markdown_link` used `\[([^\]]+)\]\(` for the label, rejecting any `]` inside link text. But CommonMark 6.3 allows balanced brackets in link text, just as it allows balanced parens in the URL (which `_find_markdown_link` already handles).

## Reproducer (before this PR)

```python
mm = '<map><node TEXT="Root"><node TEXT="array[0]"><hook NAME="ExternalObject" URI="http://x.com"/></node></node></map>'
md = c.freemind_to_markdown(mm)       # "# Root\n- [array[0]](http://x.com)"
out = c.markdown_to_freemind(md)       # TEXT="[array[0]](http://x.com)", no hook
```

The generated Markdown was well-formed, but the return trip failed to match and stored the whole bracketed string as `TEXT` while dropping the `<hook>`.

## Fix

Replace the regex with an explicit scanner that balances both `[]` in the label and `()` in the URL. The parens-balancing behavior is preserved; the brackets-balancing behavior is new.

## Tests

- `test_link_text_with_bracket_chars_not_extracted` (which encoded the buggy behavior) is renamed to `test_link_text_with_balanced_bracket_chars_extracted` and now asserts correct extraction.
- New `test_link_text_with_unbalanced_bracket_not_extracted` documents how the scanner handles an unbalanced outer `[`.
- New `TestMarkdownLinkBalancedBrackets` class adds a scanner-level test and an end-to-end `.mm -> .md -> .mm` round-trip regression test.

All 144 tests pass locally.

## Test plan

- [x] `python -m pytest -q` — 144 passed
- [x] Manual reproducer (above) confirms round-trip now preserves TEXT and URI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DuUhbWnCrZRMDft6upqA1T)_